### PR TITLE
added support to send options for juice library

### DIFF
--- a/src/openExportCommand.js
+++ b/src/openExportCommand.js
@@ -6,6 +6,8 @@ define(function() {
     let container = document.createElement("div");
     let pfx = opt.pfx || '';
     var cmdm = editor.Commands;
+    const juiceOpts = opt.juiceOpts || {};
+
     // Init code viewer
     codeViewer.set({
       codeName: 'htmlmixed',
@@ -41,7 +43,7 @@ define(function() {
         }
         md.setContent(container);
         const tmpl = editor.getHtml() + `<style>${editor.getCss()}</style>`;
-        codeViewer.setContent(opt.inlineCss ? juice(tmpl) : tmpl);
+        codeViewer.setContent(opt.inlineCss ? juice(tmpl, juiceOpts) : tmpl);
         md.open();
         viewer.refresh();
         sender && sender.set && sender.set('active', 0);

--- a/src/openExportCommand.js
+++ b/src/openExportCommand.js
@@ -13,9 +13,9 @@ define(function() {
     });
     // Set the command which could be used outside
     cmdm.add(pfx + 'get-inlined-html', {
-      run(editor) {
+      run(editor, sender, opts = {}) {
         const tmpl = editor.getHtml() + `<style>${editor.getCss()}</style>`;
-        return juice(tmpl);
+        return juice(tmpl, opts);
       }
     })
     return {


### PR DESCRIPTION
@artf ,

  This PR is to add the ability to send some options to the juice library used to inline the css into the html for the `get-inlined-html` command and when the user clicks on the `View Code` button. 

  For the command, I added as optional parameters and when the command runs, for now, it's receiving the same parameters from Juice's API.
  For the View Code button, I added a new option for the plugin called `juiceOpts`. a

  You probably know, but those are the options: https://github.com/Automattic/juice#options

  What do you think? Any change to get accepted? Suggestions? 